### PR TITLE
fixed and simplified ubuntu version comparison

### DIFF
--- a/preinstall.sh
+++ b/preinstall.sh
@@ -7,11 +7,11 @@
 ##########################################################
 
 # Installing compilation dependencies
-sudo apt install -y bc autoconf libtool libosip2-dev libortp-dev libusb-1.0-0-dev g++ sqlite3 libsqlite3-dev erlang libreadline6-dev libncurses5-dev git dpkg-dev debhelper libssl-dev cmake build-essential wget
+sudo apt install -y autoconf libtool libosip2-dev libortp-dev libusb-1.0-0-dev g++ sqlite3 libsqlite3-dev erlang libreadline6-dev libncurses5-dev git dpkg-dev debhelper libssl-dev cmake build-essential wget
 
 # Installing HD driver 4.1.0 (Ubuntu 22.04) or 4.6* (Ubuntu 24.04) & t ols from Ubuntu package manager
 ubuntu_version=$(lsb_release -rs)
-if (( $(echo "$ubuntu_version < 24.04" | bc -l) )); then
+if [ "$ubuntu_version" "<" "24.04" ]; then
     sudo apt install -y libuhd4.1.0 libzmq3-dev
 else
     sudo apt install -y libuhd4.6.0t64 cppzmq-dev


### PR DESCRIPTION
This patch fixed the Ubuntu version comparison and simplifies it to not use bc.
When using Ubuntu 22.04 using the original version, I get the following error:

./preinstall.sh: 14: 1: not found
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
E: Unable to locate package libuhd4.6.0t64
E: Couldn't find any package by glob 'libuhd4.6.0t64'
E: Unable to locate package cppzmq-dev

Since bc outputs a "1" on the string comparison, which preinstall.sh then attempts to execute.
After that, the intended packages for Ubuntu 22.04 are not installed and the rest fails.

When using Ubuntu 24.04 using the original version, I get the following error:

./preinstall.sh: 14: 0: not found
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
The following additional packages will be installed:
  comerr-dev icu-devtools krb5-multidev libboost-chrono1.83.0t64 libboost-filesystem1.83.0 libboost-serialization1.83.0 libboost-thread1.83.0 libbsd-dev libgssrpc4t64 libicu-dev
  libkadm5clnt-mit12 libkadm5srv-mit12 libkdb5-10t64 libkrb5-dev libmd-dev libmd0 libnorm-dev libnorm1t64 libpgm-5.3-0t64 libpgm-dev libsodium-dev libxml2-dev libzmq3-dev libzmq5
Suggested packages:
...

Likewise here, the result of the string comparison is executed ("0") and fails, so that by accident
the correct packages are installed on Ubuntu 24.04.

This fix simplifies the string comparison to use the builtin sh functionality and removes bc.
Tested with both Ubuntu 22.04 and 24.04.
